### PR TITLE
LocationField.cs - Add Setters to the Lat\Lng properties

### DIFF
--- a/Source/Podio .NET/Utils/ItemFields/LocationItemField.cs
+++ b/Source/Podio .NET/Utils/ItemFields/LocationItemField.cs
@@ -53,6 +53,11 @@ namespace PodioAPI.Utils.ItemFields
 
                 return null;
             }
+            set
+            {
+                EnsureValuesInitialized(true);
+                this.Values.First()["lat"] = value;
+            }        
         }
 
         public double? Longitude
@@ -65,6 +70,11 @@ namespace PodioAPI.Utils.ItemFields
                 }
 
                 return null;
+            }
+            set
+            {
+                EnsureValuesInitialized(true);
+                this.Values.First()["lng"] = value;
             }
         }
 


### PR DESCRIPTION
Since adding a Location into Podio doesn't trigger any geocoding (unless the Location is added through the Podio UI), I would like to submit Latitude & Longitude along with the address string through the API.  This allows me to use my own geocoding service to update Podio locations.