### PR TITLE
Fix query parameter used for GET /app/{app_id}

### DIFF
--- a/Source/Podio .NET/Models/Application.cs
+++ b/Source/Podio .NET/Models/Application.cs
@@ -90,6 +90,9 @@ namespace PodioAPI.Models
         [JsonProperty("item_name")]
         public string ItemName { get; set; }
 
+        [JsonProperty("space")]
+        public Space Space { get; set; }
+
 
         /// <summary>
         ///     Only for retrival

--- a/Source/Podio .NET/Services/ApplicationService.cs
+++ b/Source/Podio .NET/Services/ApplicationService.cs
@@ -21,20 +21,30 @@ namespace PodioAPI.Services
         ///     <para>Podio API Reference: https://developers.podio.com/doc/applications/get-app-22349 </para>
         /// </summary>
         /// <param name="appId"></param>
-        /// <param name="type">
+        /// <param name="view">
         ///     The type of the view of the app requested. Can be either "full", "short", "mini" or "micro". Default
         ///     value: full
         /// </param>
+        /// <param name="fields">
+        ///     This parameter can be used to include more or less content in responses than the defaults provided by Podio.
+        ///     E.g. space.view(full)
+        /// </param>
         /// <returns></returns>
-        public async Task<Application> GetApp(int appId, string type = "full")
+        public async Task<Application> GetApp(int appId, string view = "full", string fields = null)
         {
             string url = string.Format("/app/{0}", appId);
             var requestData = new Dictionary<string, string>()
             {
-                {"type", type}
+                {"view", view}
             };
+
+            if (!string.IsNullOrEmpty(fields))
+            {
+                requestData.Add("fields", fields);
+            }
+
             return await _podio.Get<Application>(url, requestData);
-            
+
         }
 
         /// <summary>


### PR DESCRIPTION
* Fix query parameter "type" -> "view" for GET /app/{app_id}, irrespective of what we pass for "type", we were receiving the same response. Changing it to "view" honors the view types correctly.

* Adding "Space" to Application Model
* Make the App Get API more generic to accept additional parameters (key, value pairs)