### PR TITLE
Change item id from int to long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Source/packages/*
  
 Source/.vs/* 
 project.lock.json
+/.vs

--- a/Source/Podio .NET/Models/Comment.cs
+++ b/Source/Podio .NET/Models/Comment.cs
@@ -7,7 +7,7 @@ namespace PodioAPI.Models
     public class Comment
     {
         [JsonProperty("comment_id")]
-        public int CommentId { get; set; }
+        public long CommentId { get; set; }
 
         [JsonProperty("value")]
         public string Value { get; set; }

--- a/Source/Podio .NET/Models/Item.cs
+++ b/Source/Podio .NET/Models/Item.cs
@@ -9,7 +9,7 @@ namespace PodioAPI.Models
     public class Item
     {
         [JsonProperty("item_id")]
-        public int ItemId { get; set; }
+        public long ItemId { get; set; }
 
         [JsonProperty("external_id")]
         public string ExternalId { get; set; }

--- a/Source/Podio .NET/Models/Reference.cs
+++ b/Source/Podio .NET/Models/Reference.cs
@@ -10,7 +10,7 @@ namespace PodioAPI.Models
         public string Type { get; set; }
 
         [JsonProperty(PropertyName = "id")]
-        public int? Id { get; set; }
+        public long? Id { get; set; }
 
         [JsonProperty(PropertyName = "title")]
         public string Title { get; private set; }

--- a/Source/Podio .NET/Services/CommentService.cs
+++ b/Source/Podio .NET/Services/CommentService.cs
@@ -20,7 +20,7 @@ namespace PodioAPI.Services
         ///     <para>Podio API Reference: https://developers.podio.com/doc/comments/delete-a-comment-22347  </para>
         /// </summary>
         /// <param name="commentId"></param>
-        public async Task<dynamic> DeleteComment(int commentId)
+        public async Task<dynamic> DeleteComment(long commentId)
         {
             string url = string.Format("/comment/{0}", commentId);
            return await  _podio.Delete<dynamic>(url);
@@ -32,7 +32,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="commentId"></param>
         /// <returns></returns>
-        public async Task<Comment> GetComment(int commentId)
+        public async Task<Comment> GetComment(long commentId)
         {
             string url = string.Format("/comment/{0}", commentId);
             return await _podio.Get<Comment>(url);
@@ -76,7 +76,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="hook">todo: describe hook parameter on AddCommentToObject</param>
         /// <returns></returns>
-        public async Task<int> AddCommentToObject(string type, long id, string text, string externalId = null,
+        public async Task<long> AddCommentToObject(string type, long id, string text, string externalId = null,
             List<int> fileIds = null, string embedUrl = null, int? embedId = null, bool alertInvite = false,
             bool silent = false, bool hook = true)
         {
@@ -108,13 +108,13 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="hook">todo: describe hook parameter on AddCommentToObject</param>
         /// <returns></returns>
-        public async Task<int> AddCommentToObject(string type, long id, CommentCreateUpdateRequest comment, bool alertInvite = false,
+        public async Task<long> AddCommentToObject(string type, long id, CommentCreateUpdateRequest comment, bool alertInvite = false,
             bool silent = false, bool hook = true)
         {
             string url = string.Format("/comment/{0}/{1}/", type, id);
             url =  Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook, null, alertInvite));
             dynamic response = await _podio.Post<dynamic>(url, comment);
-            return (int) response["comment_id"];
+            return (long) response["comment_id"];
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace PodioAPI.Services
         ///     The id of an embedded link that has been created with the Add an embed operation in the Embed
         ///     area
         /// </param>
-        public async Task<dynamic>  UpdateComment(int commentId, string text, string externalId = null, List<int> fileIds = null,
+        public async Task<dynamic>  UpdateComment(long commentId, string text, string externalId = null, List<int> fileIds = null,
             string embedUrl = null, int? embedId = null)
         {
             var requestData = new CommentCreateUpdateRequest()
@@ -151,7 +151,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="commentId"></param>
         /// <param name="comment"></param>
-        public async Task<dynamic> UpdateComment(int commentId, CommentCreateUpdateRequest comment)
+        public async Task<dynamic> UpdateComment(long commentId, CommentCreateUpdateRequest comment)
         {
             string url = string.Format("/comment/{0}", commentId);
              return await  _podio.Put<dynamic>(url, comment);

--- a/Source/Podio .NET/Services/CommentService.cs
+++ b/Source/Podio .NET/Services/CommentService.cs
@@ -76,7 +76,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="hook">todo: describe hook parameter on AddCommentToObject</param>
         /// <returns></returns>
-        public async Task<int> AddCommentToObject(string type, int id, string text, string externalId = null,
+        public async Task<int> AddCommentToObject(string type, long id, string text, string externalId = null,
             List<int> fileIds = null, string embedUrl = null, int? embedId = null, bool alertInvite = false,
             bool silent = false, bool hook = true)
         {

--- a/Source/Podio .NET/Services/CommentService.cs
+++ b/Source/Podio .NET/Services/CommentService.cs
@@ -46,7 +46,7 @@ namespace PodioAPI.Services
         /// <param name="type"></param>
         /// <param name="id"></param>
         /// <returns></returns>
-        public async Task<List<Comment>> GetCommentsOnObject(string type, int id)
+        public async Task<List<Comment>> GetCommentsOnObject(string type, long id)
         {
             string url = string.Format("/comment/{0}/{1}/", type, id);
             return await _podio.Get<List<Comment>>(url);
@@ -108,7 +108,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="hook">todo: describe hook parameter on AddCommentToObject</param>
         /// <returns></returns>
-        public async Task<int> AddCommentToObject(string type, int id, CommentCreateUpdateRequest comment, bool alertInvite = false,
+        public async Task<int> AddCommentToObject(string type, long id, CommentCreateUpdateRequest comment, bool alertInvite = false,
             bool silent = false, bool hook = true)
         {
             string url = string.Format("/comment/{0}/{1}/", type, id);

--- a/Source/Podio .NET/Services/ItemService.cs
+++ b/Source/Podio .NET/Services/ItemService.cs
@@ -357,7 +357,7 @@ namespace PodioAPI.Services
         ///     generated
         /// </param>
         /// <returns>The id of the cloned item</returns>
-        public async Task<int> CloneItem(long itemId, bool silent = false)
+        public async Task<long> CloneItem(long itemId, bool silent = false)
         {
             string url = string.Format("/item/{0}/clone", itemId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent));

--- a/Source/Podio .NET/Services/ItemService.cs
+++ b/Source/Podio .NET/Services/ItemService.cs
@@ -31,7 +31,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="hook">If set to false, hooks will not be executed for the change</param>
         /// <returns>Id of the created item</returns>
-        public async Task<int> AddNewItem(int appId, Item item, int? spaceId = null, bool silent = false, bool hook = true)
+        public async Task<long> AddNewItem(int appId, Item item, int? spaceId = null, bool silent = false, bool hook = true)
         {
             JArray fieldValues = JArray.FromObject(item.Fields.Select(f => new { external_id = f.ExternalId, field_id = f.FieldId, values = f.Values }));
 
@@ -210,7 +210,7 @@ namespace PodioAPI.Services
         ///     notifications untouched, Default value true
         /// </param>
         /// <returns></returns>
-        public async Task<Item> GetItemBasic(int itemId, bool markedAsViewed = true)
+        public async Task<Item> GetItemBasic(long itemId, bool markedAsViewed = true)
         {
             string viewedVal = markedAsViewed == true ? "1" : "0";
             var requestData = new Dictionary<string, string>()
@@ -357,12 +357,12 @@ namespace PodioAPI.Services
         ///     generated
         /// </param>
         /// <returns>The id of the cloned item</returns>
-        public async Task<int> CloneItem(int itemId, bool silent = false)
+        public async Task<int> CloneItem(long itemId, bool silent = false)
         {
             string url = string.Format("/item/{0}/clone", itemId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent));
             dynamic tw = await _podio.Post<dynamic>(url);
-            return int.Parse(tw["item_id"].ToString());
+            return long.Parse(tw["item_id"].ToString());
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace PodioAPI.Services
         ///     generated
         /// </param>
         /// <param name="hook">If set to false, hooks will not be executed for the change</param>
-        public async System.Threading.Tasks.Task DeleteItem(int itemId, bool silent = false, bool hook = true)
+        public async System.Threading.Tasks.Task DeleteItem(long itemId, bool silent = false, bool hook = true)
         {
             string url = string.Format("/item/{0}", itemId);
             url = Utility.PrepareUrlWithOptions(url, new CreateUpdateOptions(silent, hook));
@@ -387,7 +387,7 @@ namespace PodioAPI.Services
         ///     <para>Podio API Reference: https://developers.podio.com/doc/items/delete-item-reference-7302326 </para>
         /// </summary>
         /// <param name="itemId"></param>
-        public async System.Threading.Tasks.Task DeleteItemReference(int itemId)
+        public async System.Threading.Tasks.Task DeleteItemReference(long itemId)
         {
             string url = string.Format("/item/{0}/ref", itemId);
             await _podio.Delete<dynamic>(url);
@@ -509,7 +509,7 @@ namespace PodioAPI.Services
         /// <param name="itemId"></param>
         /// <param name="fieldId"></param>
         /// <returns></returns>
-        public async Task<T> GetItemFieldValues<T>(int itemId, int fieldId) where T : new()
+        public async Task<T> GetItemFieldValues<T>(long itemId, int fieldId) where T : new()
         {
             string url = string.Format("/item/{0}/value/{1}", itemId, fieldId);
             return await _podio.Get<T>(url);
@@ -522,7 +522,7 @@ namespace PodioAPI.Services
         /// <param name="itemId"></param>
         /// <param name="fieldId"></param>
         /// <returns></returns>
-        public async Task<Item> GetItemBasicByField(int itemId, string fieldId)
+        public async Task<Item> GetItemBasicByField(long itemId, string fieldId)
         {
             string url = string.Format("/item/{0}/reference/{1}/preview", itemId, fieldId);
             return await _podio.Get<Item>(url);
@@ -535,7 +535,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<List<ItemReference>> GetItemReferences(int itemId)
+        public async Task<List<ItemReference>> GetItemReferences(long itemId)
         {
             string url = string.Format("/item/{0}/reference/", itemId);
             return await _podio.Get<List<ItemReference>>(url);
@@ -573,7 +573,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<List<ItemField>> GetItemValues(int itemId)
+        public async Task<List<ItemField>> GetItemValues(long itemId)
         {
             string url = string.Format("/item/{0}/value", itemId);
             return await _podio.Get<List<ItemField>>(url);
@@ -585,7 +585,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<ItemRevision> GetItemRevision(int itemId, int revision)
+        public async Task<ItemRevision> GetItemRevision(long itemId, int revision)
         {
             string url = string.Format("/item/{0}/revision/{1}", itemId, revision);
             return await _podio.Get<ItemRevision>(url);
@@ -597,7 +597,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<List<ItemRevision>> GetItemRevisions(int itemId)
+        public async Task<List<ItemRevision>> GetItemRevisions(long itemId)
         {
             string url = string.Format("/item/{0}/revision/", itemId);
             return await _podio.Get<List<ItemRevision>>(url);
@@ -610,7 +610,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<string> GetMeetingUrl(int itemId)
+        public async Task<string> GetMeetingUrl(long itemId)
         {
             string url = string.Format("/item/{0}/meeting/url", itemId);
             dynamic response = await _podio.Get<dynamic>(url);
@@ -626,7 +626,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <param name="status">The new status, either "invited", "accepted", "declined" or "tentative"</param>
-        public async System.Threading.Tasks.Task SetParticipation(int itemId, string status)
+        public async System.Threading.Tasks.Task SetParticipation(long itemId, string status)
         {
             dynamic requestData = new
             {
@@ -644,7 +644,7 @@ namespace PodioAPI.Services
         /// <param name="fieldId"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        public async Task<List<ItemMicro>> GetReferencesToItemByField(int itemId, int fieldId, int limit = 20)
+        public async Task<List<ItemMicro>> GetReferencesToItemByField(long itemId, int fieldId, int limit = 20)
         {
             var requestData = new Dictionary<string, string>()
             {
@@ -661,7 +661,7 @@ namespace PodioAPI.Services
         /// <param name="itemId"></param>
         /// <param name="type">The type of the reference</param>
         /// <param name="id">The id of the reference</param>
-        public async System.Threading.Tasks.Task UpdateItemReference(int itemId, string type, int referenceId)
+        public async System.Threading.Tasks.Task UpdateItemReference(long itemId, string type, int referenceId)
         {
             dynamic requestData = new
             {
@@ -680,7 +680,7 @@ namespace PodioAPI.Services
         /// <param name="itemId"></param>
         /// <param name="revisionId"></param>
         /// <returns>The id of the new revision</returns>
-        public async Task<int?> RevertItemRevision(int itemId, int revisionId)
+        public async Task<int?> RevertItemRevision(long itemId, int revisionId)
         {
             var url = string.Format("/item/{0}/revision/{1}", itemId, revisionId);
             var response = await _podio.Delete<dynamic>(url);
@@ -698,7 +698,7 @@ namespace PodioAPI.Services
         /// <param name="itemId"></param>
         /// <param name="revision"></param>
         /// <returns>revision</returns>
-        public async Task<int?> RevertToRevision(int itemId, int revision)
+        public async Task<int?> RevertToRevision(long itemId, int revision)
         {
             var url = string.Format("/item/{0}/revision/{1}/revert_to", itemId, revision);
             var response = await _podio.Delete<dynamic>(url);
@@ -744,7 +744,7 @@ namespace PodioAPI.Services
         /// </summary>
         /// <param name="itemId"></param>
         /// <returns></returns>
-        public async Task<Clone> GetItemClone(int itemId)
+        public async Task<Clone> GetItemClone(long itemId)
         {
             string url = string.Format("/item/{0}/clone", itemId);
             return await _podio.Get<Clone>(url);
@@ -758,13 +758,13 @@ namespace PodioAPI.Services
         /// <param name="revisionFrom"></param>
         /// <param name="revisionTo"></param>
         /// <returns></returns>
-        public async Task<List<ItemDiff>> GetItemRevisionDifference(int itemId, int revisionFrom, int revisionTo)
+        public async Task<List<ItemDiff>> GetItemRevisionDifference(long itemId, int revisionFrom, int revisionTo)
         {
             string url = string.Format("/item/{0}/revision/{1}/{2}", itemId, revisionFrom, revisionTo);
             return await _podio.Get<List<ItemDiff>>(url);
         }
 
-        public async Task<ItemCalculate> Calcualate(int itemId, ItemCalculateRequest ItemCalculateRequest, int limit = 30)
+        public async Task<ItemCalculate> Calcualate(long itemId, ItemCalculateRequest ItemCalculateRequest, int limit = 30)
         {
             ItemCalculateRequest.Limit = ItemCalculateRequest.Limit == 0 ? 30 : ItemCalculateRequest.Limit;
             string url = string.Format("/item/app/{0}/calculate", itemId);

--- a/Source/Podio .NET/Services/ItemService.cs
+++ b/Source/Podio .NET/Services/ItemService.cs
@@ -188,7 +188,7 @@ namespace PodioAPI.Services
         ///     If true marks any new notifications on the given item as viewed, otherwise leaves any
         ///     notifications untouched, Default value true
         /// </param>
-        public async Task<Item> GetItem(int itemId, bool markedAsViewed = true)
+        public async Task<Item> GetItem(long itemId, bool markedAsViewed = true)
         {
             string markAsViewdValue = markedAsViewed == true ? "1" : "0";
             var requestData = new Dictionary<string, string>()
@@ -472,7 +472,7 @@ namespace PodioAPI.Services
         /// <param name="limit">The maximum number of results to return Default value: 13</param>
         /// <param name="notItemIds">If supplied the items with these ids will not be returned</param>
         /// <returns></returns>
-        public async Task<List<Item>> GetTopValuesByField(int fieldId, int limit = 13, int[] notItemIds = null)
+        public async Task<List<Item>> GetTopValuesByField(int fieldId, int limit = 13, long[] notItemIds = null)
         {
             string itemIdCSV = Utility.ArrayToCSV(notItemIds);
             var requestData = new Dictionary<string, string>()
@@ -723,7 +723,7 @@ namespace PodioAPI.Services
         /// </param>
         /// <param name="text">The text to search for. The search will be lower case, and with a wildcard in each end.</param>
         /// <returns></returns>
-        public async Task<List<Item>> FindReferenceableItems(int fieldId, int limit = 13, int[] notItemIds = null,
+        public async Task<List<Item>> FindReferenceableItems(int fieldId, int limit = 13, long[] notItemIds = null,
             string sort = null, string text = null)
         {
             string itemIdCSV = Utility.ArrayToCSV(notItemIds);

--- a/Source/Podio .NET/Utils/Utilities.cs
+++ b/Source/Podio .NET/Utils/Utilities.cs
@@ -18,6 +18,14 @@ namespace PodioAPI.Utils
             return string.Empty;
         }
 
+        internal static string ArrayToCSV(long[] array, string splitter = ",")
+        {
+            if (array != null && array.Length > 0)
+                return string.Join(splitter, array);
+
+            return string.Empty;
+        }
+
         internal static string ArrayToCSV(string[] array, string splitter = ",")
         {
             if (array != null && array.Length > 0)


### PR DESCRIPTION
The item id for newly created items no longer fits within an int, thus throwing an exception when such items are parsed.